### PR TITLE
Trim api key data to prevent unauthorized error

### DIFF
--- a/porkbun/porkbun.go
+++ b/porkbun/porkbun.go
@@ -49,7 +49,7 @@ func (e *PorkbunSolver) readConfig(request *acme.ChallengeRequest) (*porkbun.Cli
 		return nil, err
 	}
 
-	return porkbun.New(secretKey, apiKey), nil
+	return porkbun.New(strings.TrimSpace(secretKey), strings.TrimSpace(apiKey)), nil
 }
 
 func (e *PorkbunSolver) resolveSecretRef(selector corev1.SecretKeySelector, ch *acme.ChallengeRequest) (string, error) {


### PR DESCRIPTION
I don't know any go so idk if it was a go version issue or a os issue or something, but the api key and secret for porkbun was getting a newline added somewhere (after base64 encoding).

go: 1.22.0
Ubuntu: 22.04 (through wsl)